### PR TITLE
giving TAMs ability to stop queries

### DIFF
--- a/cfn/templates/tam-trust.yaml
+++ b/cfn/templates/tam-trust.yaml
@@ -38,6 +38,7 @@ Resources:
                   - athena:GetQueryResults
                   - athena:RunQuery
                   - athena:StartQueryExecution
+                  - athena:StopQueryExecution
                   - athena:ListQueryExecutions
                   - athena:BatchGetQueryExecution
                   - athena:ListNamedQueries


### PR DESCRIPTION
I accidentally ran a big query and discovered that the TAM role can't stop query execution.